### PR TITLE
update crack to remove dependency on safe_yaml which won't run in Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     ruby-pardot (1.4.1)
-      crack (= 0.4.3)
+      crack (= 0.4.5)
       httparty (= 0.21.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.4.4)
     fakeweb (1.3.0)
     httparty (0.21.0)
@@ -17,6 +17,7 @@ GEM
       multi_xml (>= 0.5.2)
     mini_mime (1.1.2)
     multi_xml (0.6.0)
+    rexml (3.2.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -30,7 +31,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    safe_yaml (1.0.5)
 
 PLATFORMS
   ruby
@@ -42,4 +42,4 @@ DEPENDENCIES
   ruby-pardot!
 
 BUNDLED WITH
-   2.2.7
+   2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       multi_xml (>= 0.5.2)
     mini_mime (1.1.2)
     multi_xml (0.6.0)
+    rake (13.0.6)
     rexml (3.2.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -38,6 +39,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 1.10)
   fakeweb (= 1.3.0)
+  rake
   rspec (= 3.5.0)
   ruby-pardot!
 

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'httparty', '0.21.0'
 
   s.add_development_dependency "bundler", ">= 1.10"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "3.5.0"
   s.add_development_dependency "fakeweb", "1.3.0"
 

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-pardot"
 
-  s.add_dependency 'crack', '0.4.3'
+  s.add_dependency 'crack', '0.4.5'
   s.add_dependency 'httparty', '0.21.0'
 
   s.add_development_dependency "bundler", ">= 1.10"


### PR DESCRIPTION
`safe_yaml` hasn't been updated to work in Ruby 3, but `crack` _has_ been updated not to depend on it. This should get us one step closer to updating [zappistore.app](https://github.com/Intellection/zappistore.app) to run on Ruby 3.

I've also opened pull request pardot#62 against the upstream repository, but that repository doesn't seem to be getting much attention lately. It hasn't had a commit for 19 months and pardot#60 (which does basically the same job as mine) has been open for four months.